### PR TITLE
Apply own syntax highlight

### DIFF
--- a/syntax/quadlet.vim
+++ b/syntax/quadlet.vim
@@ -30,7 +30,7 @@ syn region quadletValue start=/=\s*/ms=s+1,hs=s+1
       \ skip=/\\\s*$/
       \ contains=quadletCont
 
-hi def link quadletHeader   Modemsg
+hi def link quadletHeader   ModeMsg
 hi def link quadletComment  Comment
 hi def link quadletLabel    Identifier
 hi def link quadletValue    String


### PR DESCRIPTION
The [dosinig](https://github.com/vim/vim/blob/master/runtime/syntax/dosini.vim) has been reused. But this does not have line continuation sign. So I made Quadlet syntax that respect the continuation sign.

The dosini version:
<img width="602" height="372" alt="image" src="https://github.com/user-attachments/assets/3e08258f-88b9-4d19-bffb-5df0a8b0e3db" />

The quadlet version:
<img width="561" height="381" alt="image" src="https://github.com/user-attachments/assets/1c24abf6-b6bc-4600-86e9-bd61367a7801" />
