### PR TITLE
Add different color to separators

### DIFF
--- a/syntax/quadlet.vim
+++ b/syntax/quadlet.vim
@@ -13,28 +13,34 @@ set cpo&vim
 " shut case off
 syn case ignore
 
-syn match  quadletLabel   "^.\{-}\ze\s*=" nextgroup=quadletValue
+syn match  quadletLabel   "^.\{-}\ze\s*=" nextgroup=quadletAssign skipwhite
 syn region quadletHeader  start="^\s*\[" end="\]"
 syn match  quadletComment "^[#;].*$" contains=@Spell
 
-" Visual marker for the trailing backslash
-syn match quadletCont "\\\s*$"
+syn match quadletAssign "=" contained nextgroup=quadletValue skipwhite
 
 " Multi-line value:
 "  - starts right after '='
 "  - ends at end of line, UNLESS the line ends with '\'
 "  - extend/keepend lets it flow across lines
-syn region quadletValue start=/=\s*/ms=s+1,hs=s+1
-      \ end=/$/
-      \ keepend extend
-      \ skip=/\\\s*$/
-      \ contains=quadletCont
+syn region quadletValue start=/\s*/ms=s,hs=s
+    \ end=/$/
+    \ keepend extend
+    \ skip=/\\\s*$/
+    \ contains=quadletCont,quadletSep
+    \ contained
 
-hi def link quadletHeader   ModeMsg
-hi def link quadletComment  Comment
-hi def link quadletLabel    Identifier
-hi def link quadletValue    String
-hi def link quadletCont     Special
+" Effects in the quadletValue
+syn match quadletCont "\\\s*$"  contained
+syn match quadletSep  "[:=,/]"   contained
+
+hi def link quadletHeader    ModeMsg
+hi def link quadletComment   Comment
+hi def link quadletLabel     Identifier
+hi def link quadletValue     String
+hi def link quadletCont      Special
+hi def link quadletSep       Operator
+hi def link quadletAssign    Special
 
 let b:current_syntax = 'quadlet'
 


### PR DESCRIPTION
To make it easier to read, give separators different color in value. For example with carbonfox.

<img width="813" height="594" alt="image" src="https://github.com/user-attachments/assets/5c5400e8-d8a2-474e-bf4d-583ec6a1601d" />

